### PR TITLE
feat:Add bzip2 to support some npm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkinsxio/builder-base:0.0.227
 
 RUN curl --silent --location https://rpm.nodesource.com/setup_9.x | bash - && \
-  yum install -y nodejs gcc-c++ make
+  yum install -y nodejs gcc-c++ make bzip2


### PR DESCRIPTION
Some npm packages require bzip2 in order to install so it would be helpful to have this available out of the box.